### PR TITLE
Arranger docker image ghcr migration

### DIFF
--- a/arranger/Chart.yaml
+++ b/arranger/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1

--- a/arranger/values.yaml
+++ b/arranger/values.yaml
@@ -66,7 +66,7 @@ autoscaling:
 #  API Values
 ##############################
 apiImage:
-  repository: overture/arranger-server
+  repository: ghcr.io/overture-stack/arranger-server
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "2.4.0"
@@ -90,7 +90,7 @@ apiIngress:
 #  UI Values
 ##############################
 uiImage:
-  repository: overture/arranger-ui
+  repository: ghcr.io/overture-stack/arranger-ui
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "2.4.0"

--- a/arranger/values.yaml
+++ b/arranger/values.yaml
@@ -69,7 +69,7 @@ apiImage:
   repository: ghcr.io/overture-stack/arranger-server
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.4.0"
+  tag: "latest"
 
 apiConfig:
   host: https://arranger-api.local
@@ -93,7 +93,7 @@ uiImage:
   repository: ghcr.io/overture-stack/arranger-ui
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.4.0"
+  tag: "latest"
 
 uiConfig:
   enabled: false


### PR DESCRIPTION
## Changed
- arranger chart - changed default image source from dockerhub to github packages url
- arranger chart - changed server and ui default image tags from explicit version to latest
- arranger chart - bumped version to 0.1.1